### PR TITLE
relevant links on navbar when logged in and logged out

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -3,5 +3,5 @@
   height: 100px;
   float: right;
   position: relative;
-  bottom: 50px;
+  bottom: 0px;
   }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -47,7 +47,7 @@
 
 /* Dropdown menu */
 .navbar-wagon-dropdown-menu {
-  margin-top: 15px;
+  margin-top: 38px;
   box-shadow: 1px 1px 4px #E6E6E6;
   border-color: #E6E6E6;
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,8 +10,8 @@
     <% if user_signed_in? %>
 
       <!-- Links when logged in -->
-      <%= link_to "Réserver", "#", class: "navbar-wagon-item navbar-wagon-link" %>
-      <%= link_to "Ajouter", "#", class: "navbar-wagon-item navbar-wagon-link" %>
+      <%= link_to "Réserver", root_path, class: "navbar-wagon-item navbar-wagon-link" %>
+      <%= link_to "Ajouter", new_watch_path, class: "navbar-wagon-item navbar-wagon-link" %>
       <%= link_to "Messages", "#", class: "navbar-wagon-item navbar-wagon-link" %>
 
       <!-- Avatar with dropdown menu -->
@@ -20,18 +20,13 @@
           <%= image_tag "http://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbar-wagon-menu", "data-toggle" => "dropdown" %>
           <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
             <li>
-              <%= link_to "#" do %>
-                <i class="fa fa-user"></i> <%= t(".profile", default: "Profile") %>
-              <% end %>
-            </li>
-            <li>
-              <%= link_to "#" do %>
-                <i class="fa fa-cog"></i>  <%= t(".settings", default: "Settings") %>
+              <%= link_to user_path(current_user) do %>
+                <i class="fa fa-user"></i> <%= t(".profile", default: "Mon Profil") %>
               <% end %>
             </li>
             <li>
               <%= link_to destroy_user_session_path, method: :delete do %>
-                <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Log out") %>
+                <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Deconnexion") %>
               <% end %>
             </li>
           </ul>
@@ -39,6 +34,8 @@
       </div>
     <% else %>
       <!-- Login link (when logged out) -->
+      <%= link_to "Réserver", root_path, class: "navbar-wagon-item navbar-wagon-link" %>
+      <%= link_to "Ajouter", new_watch_path, class: "navbar-wagon-item navbar-wagon-link" %>
       <%= link_to t(".sign_in", default: "Login"), new_user_session_path, class: "navbar-wagon-item navbar-wagon-link" %>
     <% end %>
   </div>


### PR DESCRIPTION
missing link on "messages" when logged in : 

![image](https://user-images.githubusercontent.com/37231983/44403918-ece47b00-a555-11e8-9093-bc021e3d1906.png)

![image](https://user-images.githubusercontent.com/37231983/44403929-f241c580-a555-11e8-9686-b04eac8b780a.png)

![image](https://user-images.githubusercontent.com/37231983/44403908-e81fc700-a555-11e8-8277-ebcaac06e69d.png)
