### PR TITLE
adding google key API to show to final map design

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       <%= yield %>
       <%= render 'shared/footer' %>
       <%= javascript_include_tag 'application' %>
-      <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js" %>
+      <<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places&key=#{ENV['GOOGLE_API_BROWSER_KEY']}" %>
       <%= javascript_pack_tag 'application' %>
       <%= javascript_pack_tag "map" %>
     </body>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,7 @@ Geocoder.configure(
   # use_https: false,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  # api_key: nil,               # API key for geocoding service
+  api_key:   ENV['GOOGLE_API_SERVER_KEY'],             # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 
@@ -18,5 +18,6 @@ Geocoder.configure(
 
   # Calculation options
   units: :km,                 # :km for kilometers or :mi for miles
+  use_https: true,
   # distances: :linear          # :spherical or :linear
 )


### PR DESCRIPTION
we must add 
```GOOGLE_API_BROWSER_KEY=AIzaSyDeacI-QzHqJ_nz6aXujJG5O6Vpid-XiI0```
in .env 

and @efoucault for Heroku : 

```heroku config:set GOOGLE_API_BROWSER_KEY=AIzaSyDeacI-QzHqJ_nz6aXujJG5O6Vpid-XiI0```
